### PR TITLE
Symfony 5 compatibility

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ami_airbrake');
+        $treeBuilder = new TreeBuilder('ami_airbrake');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,7 +18,9 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('ami_airbrake');
-        $rootNode = $treeBuilder->getRootNode();
+        $rootNode = \method_exists($treeBuilder, "getRootNode")
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root("ami_airbrake"); // BC layer for symfony 4.1 and older
 
         $rootNode
             ->children()

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "type": "symfony-bundle",
     "require": {
-        "symfony/framework-bundle": "^2.8|^3.0|^4.0",
+        "symfony/framework-bundle": "^2.8|^3.0|^4.0|^5.0",
         "airbrake/phpbrake": "^0.6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Resolve a deprecation in TreeBuilder and allow `symfony/framework-bundle` as a valid dependency