### PR TITLE
- changed root variables

### DIFF
--- a/DependencyInjection/AmiAirbrakeExtension.php
+++ b/DependencyInjection/AmiAirbrakeExtension.php
@@ -48,7 +48,7 @@ class AmiAirbrakeExtension extends Extension
                         'environment'   => key_exists('env', $config) && $config['env'] ?
                             $config['env'] :
                             $container->getParameter('kernel.environment'),
-                        'rootDirectory' => dirname($container->getParameter('kernel.root_dir'))
+                        'rootDirectory' => dirname($container->getParameter('kernel.project_dir'))
                     ]]
                 )
             );
@@ -84,7 +84,7 @@ class AmiAirbrakeExtension extends Extension
 
     public function getAppVersion(ContainerBuilder $container)
     {
-        $rootDir = dirname($container->getParameter('kernel.root_dir'));
+        $rootDir = dirname($container->getParameter('kernel.project_dir'));
 
         return file_exists("$rootDir/REVISION") ? trim(file_get_contents("$rootDir/REVISION")) : null;
     }

--- a/Tests/DependencyInjection/AmiAirbrakeExtensionTest.php
+++ b/Tests/DependencyInjection/AmiAirbrakeExtensionTest.php
@@ -24,7 +24,7 @@ class AmiAirbrakeExtensionTest extends TestCase
     protected function setUp(): void
     {
         $this->container = new ContainerBuilder(new ParameterBag([
-            'kernel.root_dir'    => __DIR__,
+            'kernel.project_dir'    => __DIR__,
             'kernel.bundles'     => ['AmiAirbrakeBundle' => true],
             'kernel.environment' => 'test',
         ]));


### PR DESCRIPTION
- This PR fixes "You have requested a non-existent parameter "kernel.root_dir". Did you mean one of these: "kernel.project_dir", "kernel.cache_dir", "kernel.logs_dir"?" Error on Symfony5.0.8